### PR TITLE
Fix always wait fetch with `-m` option

### DIFF
--- a/lgtm.sh
+++ b/lgtm.sh
@@ -19,25 +19,41 @@ lgtm_markdown() {
 lgtm() {
     if [ -s $cachefile ]; then
         cat $cachefile
-        ( lgtm_nocache > $cachefile ) &
     else
-        ( lgtm_nocache > $cachefile ) & lgtm_nocache
+        lgtm_nocache
     fi
 }
 
 lgtm_nocache() {
-    site=${sites[$(($RANDOM % ${#sites[@]}))]}
-    echo 'http://lgtm.herokuapp.com/'$(curl -sL ${site}random | pup 'meta[name=twitter:image]' 'attr{content}')
+  echo $(fetch)
 }
 
-case "$1" in
-    -m)
-        lgtm_markdown
-        ;;
-    '')
-        lgtm
-        ;;
-    *)
-        usage
-        ;;
-esac
+fetch() {
+    site=${sites[$(($RANDOM % ${#sites[@]}))]}
+    local id=$(curl -sL ${site}random | pup 'meta[name=twitter:image]' 'attr{content}')
+    echo "http://lgtm.herokuapp.com/$id"
+}
+
+cache() {
+  (
+    local url=$(lgtm_nocache)
+    echo "$url" > $cachefile
+  ) &
+}
+
+main() {
+  case "$1" in
+      -m)
+          lgtm_markdown
+          ;;
+      '')
+          lgtm
+          ;;
+      *)
+          usage
+          ;;
+  esac
+}
+
+main $1
+cache


### PR DESCRIPTION
When we use `-m` option to get markdown format LGTM, always wait fetching new image is done.
Because `$(lgtm)` waits lgtm function return. That means wait fetching is done.

(And tiny hack for hasty use: cache file is updated when fetch is completely done.)

:hamster: 
